### PR TITLE
revert to Elixir 1.15.7 and add .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.15.7-otp-26
+erlang 26.1

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Astarte.Core.Generators.MixProject do
     [
       app: :astarte_generators,
       version: "0.1.0",
-      elixir: "~> 1.18",
+      elixir: "~> 1.15.7",
       start_permanent: Mix.env() == :prod,
       deps: deps() ++ astarte_required_modules(),
       package: package()


### PR DESCRIPTION
- Downgraded Elixir to version 1.15.7 for compatibility.
- Added .tool-versions to specify the required Elixir version.