### PR TITLE
device generator

### DIFF
--- a/lib/astarte/core/generators/device.ex
+++ b/lib/astarte/core/generators/device.ex
@@ -1,0 +1,171 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Core.Generators.Device do
+  @moduledoc """
+  This module provides generators for Astarte Device.
+
+  See https://hexdocs.pm/astarte_core/Astarte.Core.Device.html
+
+  """
+  use ExUnitProperties
+  alias Astarte.Common.Generators.Ip, as: IpGenerator
+  alias Astarte.Common.Generators.Timestamp, as: TimestampGenerator
+  alias Astarte.Core.Device
+  alias Astarte.Core.Interface
+
+  @doc """
+  Generates a valid Astarte Device with pre-created interfaces_bytes
+  TODO: using `ecto_strea_factory` in the future
+  """
+  @spec device(interfaces: [Interface.t()]) :: StreamData.t(map())
+  def device(interfaces: interfaces) do
+    gen all id <- id(),
+            last_seen_ip <- IpGenerator.ip(:ipv4),
+            last_credentials_request_ip <- IpGenerator.ip(:ipv4),
+            inhibit_credentials_request <- boolean(),
+            {
+              first_registration,
+              first_credentials_request,
+              last_connection,
+              last_disconnection
+            } <- dates(),
+            {
+              total_received_msgs,
+              total_received_bytes,
+              interfaces_msgs,
+              interfaces_bytes
+            } <-
+              interfaces
+              |> interfaces_data()
+              |> constant(),
+            aliases <- aliases(),
+            attributes <- attributes() do
+      %{
+        id: id,
+        device_id: id,
+        encoded_id: Device.encode_device_id(id),
+        connected: last_connection >= last_disconnection,
+        first_registration: first_registration,
+        first_credentials_request: first_credentials_request,
+        last_connection: last_connection,
+        last_disconnection: last_disconnection,
+        last_seen_ip: last_seen_ip,
+        inhibit_credentials_request: inhibit_credentials_request,
+        last_credentials_request_ip: last_credentials_request_ip,
+        interfaces_msgs: interfaces_msgs,
+        interfaces_bytes: interfaces_bytes,
+        aliases: aliases,
+        attributes: attributes,
+        total_received_msgs: total_received_msgs,
+        total_received_bytes: total_received_bytes
+      }
+    end
+  end
+
+  @doc """
+  Generates a valid Astarte Device id
+
+  See https://docs.astarte-platform.org/astarte/latest/010-design_principles.html#device-id
+  """
+  @spec id() :: StreamData.t(<<_::128>>)
+  def id do
+    gen all seq <- binary(length: 16) do
+      <<u0::48, _::4, u1::12, _::2, u2::62>> = seq
+      <<u0::48, 4::4, u1::12, 2::2, u2::62>>
+    end
+  end
+
+  @doc """
+  Generates a valid Astarte encoded Device id
+  """
+  @spec encoded_id() :: StreamData.t(String.t())
+  def encoded_id do
+    gen all id <- id() do
+      Base.url_encode64(id, padding: false)
+    end
+  end
+
+  # Interface utility functions
+  defp interface_row(%Interface{name: name}), do: {name, 0..1 |> Enum.random()}
+  defp interface_map([]), do: {0, 0, nil, nil}
+  defp interface_map([], acc), do: acc
+
+  defp interface_map([key | tail], {total_msgs, total_bytes, msgs, bytes}) do
+    m = Enum.random(1..10_000)
+    b = Enum.random(10..10_000)
+
+    acc = {
+      total_msgs + m,
+      total_bytes + b,
+      Map.merge(msgs, %{key => m}),
+      Map.merge(bytes, %{key => b})
+    }
+
+    interface_map(tail, acc)
+  end
+
+  defp interfaces_data([]), do: interface_map([])
+  defp interfaces_data(%Interface{} = interface), do: interfaces_data([interface])
+
+  defp interfaces_data(interfaces) when is_list(interfaces) do
+    interfaces
+    |> Stream.map(&interface_row/1)
+    |> Enum.uniq_by(fn {n, _} -> n end)
+    |> interface_map({0, 0, %{}, %{}})
+  end
+
+  defp aliases do
+    [
+      map_of(string(:alphanumeric, min_length: 1), string(:alphanumeric, min_length: 1)),
+      constant(nil)
+    ]
+    |> one_of()
+  end
+
+  defp attributes do
+    [
+      map_of(
+        string(:alphanumeric, min_length: 1),
+        string(:alphanumeric, min_length: 1)
+      ),
+      constant(nil)
+    ]
+    |> one_of()
+  end
+
+  defp dates do
+    now = "Etc/UTC" |> DateTime.now!() |> DateTime.to_unix()
+
+    gen all last_disconnection <-
+              TimestampGenerator.timestamp(max: now),
+            last_connection <-
+              TimestampGenerator.timestamp(max: last_disconnection),
+            first_credentials_request <-
+              TimestampGenerator.timestamp(max: last_connection),
+            first_registration <-
+              TimestampGenerator.timestamp(max: first_credentials_request) do
+      {
+        first_registration,
+        first_credentials_request,
+        last_connection,
+        last_disconnection
+      }
+    end
+  end
+end

--- a/test/astarte/core/generators/device_test.exs
+++ b/test/astarte/core/generators/device_test.exs
@@ -1,0 +1,80 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Core.Generators.DeviceTest do
+  @moduledoc """
+  Tests for Astarte Device generator.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Astarte.Core.Device
+  alias Astarte.Core.Generators.Device, as: DeviceGenerator
+  alias Astarte.Core.Generators.Interface, as: InterfaceGenerator
+
+  @moduletag :device
+
+  @device_id_size 16
+
+  @doc """
+  Property test for Astarte Device generator Ids.
+  """
+  describe "device generator ids" do
+    @tag :success
+    property "success valid device id size" do
+      check all(device_id <- DeviceGenerator.id()) do
+        assert byte_size(device_id) == @device_id_size,
+               "Device id is not #{@device_id_size} bytes"
+      end
+    end
+
+    @tag :success
+    property "success encode device id" do
+      check all(device_id <- DeviceGenerator.id()) do
+        encoded_device_id_1 = Base.url_encode64(device_id, padding: false)
+        encoded_device_id_2 = Device.encode_device_id(device_id)
+        assert encoded_device_id_1 == encoded_device_id_2
+      end
+    end
+
+    @tag :success
+    property "success decode device id" do
+      check all(encoded_device_id <- DeviceGenerator.encoded_id()) do
+        {:ok, device_id_1} = Base.url_decode64(encoded_device_id, padding: false)
+        {:ok, device_id_2} = Device.decode_device_id(encoded_device_id)
+        assert device_id_1 == device_id_2
+      end
+    end
+  end
+
+  @doc """
+  Property test for Astarte Device struct.
+  """
+  describe "device generator struct" do
+    @tag :success
+    property "success base device creation" do
+      check all(
+              interfaces <-
+                InterfaceGenerator.interface() |> list_of(min_length: 0, max_length: 100),
+              device <- DeviceGenerator.device(interfaces: interfaces)
+            ) do
+        refute device == nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added `device` generator.

### Description
This PR introduces the `device` generator. The generator requires "concrete" `interfaces` because it does not use all the available data from them. Relying on the preexisting `Generator.Interface` would make it impossible to retrieve the necessary data.

## Note
In the future, it may be possible to add support for using the preexisting `Generator.Interface` to autogenerate internal data.