### PR TITLE
Consolidate project code

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -28,7 +28,7 @@
       checks: [
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 100},
         {Credo.Check.Readability.Specs},
-        {Credo.Check.Design.TagTODO, exit_status: 2},
+        {Credo.Check.Design.TagTODO, exit_status: 0},
         {Credo.Check.Design.AliasUsage, priority: :low},
         {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 10},
         {Credo.Check.Refactor.FunctionArity, max_arity: 4},

--- a/test/astarte/core/generators/device_test.exs
+++ b/test/astarte/core/generators/device_test.exs
@@ -31,9 +31,7 @@ defmodule Astarte.Core.Generators.DeviceTest do
 
   @device_id_size 16
 
-  @doc """
-  Property test for Astarte Device generator Ids.
-  """
+  @doc false
   describe "device generator ids" do
     @tag :success
     property "success valid device id size" do
@@ -62,9 +60,7 @@ defmodule Astarte.Core.Generators.DeviceTest do
     end
   end
 
-  @doc """
-  Property test for Astarte Device struct.
-  """
+  @doc false
   describe "device generator struct" do
     @tag :success
     property "success base device creation" do

--- a/test/astarte/core/generators/device_test.exs
+++ b/test/astarte/core/generators/device_test.exs
@@ -68,7 +68,7 @@ defmodule Astarte.Core.Generators.DeviceTest do
               interfaces <-
                 InterfaceGenerator.interface() |> list_of(min_length: 0, max_length: 10),
               device <- DeviceGenerator.device(interfaces: interfaces),
-              max_runs: 300
+              max_runs: 100
             ) do
         refute device == nil
       end

--- a/test/astarte/core/generators/interface_test.exs
+++ b/test/astarte/core/generators/interface_test.exs
@@ -29,15 +29,25 @@ defmodule Astarte.Core.Generators.InterfaceTest do
 
   @moduletag :interface
 
-  @doc """
-  Property test for Astarte Interface generator.
-  """
-  describe "interface generator" do
-    property "validate interface" do
-      check all(interface <- InterfaceGenerator.interface()) do
-        %Changeset{valid?: valid, errors: errors} = Interface.changeset(interface)
+  defp validation_helper(interface) do
+    Interface.changeset(interface)
+  end
 
-        assert valid, "Invalid interface: " <> (errors |> Enum.join(", "))
+  defp validation_fixture(_context), do: {:ok, validate: &validation_helper/1}
+
+  @doc false
+  describe "interface generator" do
+    @describetag :success
+    @describetag :ut
+
+    setup :validation_fixture
+
+    property "validate interface using Changeset", %{validate: validate} do
+      check all(
+              interface <- InterfaceGenerator.interface(),
+              changeset = validate.(interface)
+            ) do
+        assert changeset.valid?, "Invalid interface: #{inspect(changeset.errors)}"
       end
     end
   end

--- a/test/astarte/core/generators/triggers/policy/error_range_test.exs
+++ b/test/astarte/core/generators/triggers/policy/error_range_test.exs
@@ -31,21 +31,15 @@ defmodule Astarte.Core.Generators.Triggers.Policy.ErrorRangeTest do
   @moduletag :policy
   @moduletag :error_range
 
-  # ? TODO move validate to a fixture file and make it generic
-  defp validation_fixture(_context) do
-    {
-      :ok,
-      validate: fn %ErrorRange{} = error_range ->
-        error_range
-        |> Changeset.change()
-        |> ErrorRange.validate()
-      end
-    }
+  defp validation_helper(error_keyword) do
+    error_keyword
+    |> Changeset.change()
+    |> ErrorRange.validate()
   end
 
-  @doc """
-  Property test for Astarte Triggers Policy ErrorRange generator.
-  """
+  defp validation_fixture(_context), do: {:ok, validate: &validation_helper/1}
+
+  @doc false
   describe "triggers policy error_range generator" do
     @describetag :success
     @describetag :ut


### PR DESCRIPTION
## Description

### Points
The pr consolidates several points and makes them homogeneous, for proper continuation of project work
- added `@doc false` test
- `credo` _TODO rule_ will not block the CI anymore
- used the same design pattern for tests requiring a _Changeset_
- further reduced the number of `max_runs` for `DeviceGenerator` tests