### PR TITLE
feat!: parametric generators

### DIFF
--- a/lib/astarte/core/generators/group.ex
+++ b/lib/astarte/core/generators/group.ex
@@ -24,6 +24,10 @@ defmodule Astarte.Core.Generators.Group do
   """
   use ExUnitProperties
 
+  alias Astarte.Core.Generators.Device
+
+  import ParameterizedStreams
+
   @max_subpath_count 10
   @max_subpath_length 20
 
@@ -40,14 +44,12 @@ defmodule Astarte.Core.Generators.Group do
     end)
   end
 
-  @spec group([{:devices, any()}, ...]) :: StreamData.t(map())
-  def group(devices: devices) do
+  @spec group() :: StreamData.t(map())
+  @spec group(keyword()) :: StreamData.t(map())
+  def group(params \\ []) do
     gen all(
-          name <- name(),
-          device_ids <-
-            devices
-            |> Enum.map(fn i -> i.device_id end)
-            |> constant()
+          name <- gen_param(name(), :name, params),
+          device_ids <- gen_param(uniq_list_of(Device.id()), :device_ids, params)
         ) do
       %{
         name: name,

--- a/lib/astarte/core/generators/interface.ex
+++ b/lib/astarte/core/generators/interface.ex
@@ -128,7 +128,7 @@ defmodule Astarte.Core.Generators.Interface do
           allow_unset <- gen_param(MappingGenerator.allow_unset(), :allow_unset, params),
           explicit_timestamp <-
             gen_param(MappingGenerator.explicit_timestamp(), :explicit_timestamp, params),
-          mappings_args = %{
+          mappings_args = [
             aggregation: aggregation,
             prefix: prefix,
             retention: retention,
@@ -136,7 +136,7 @@ defmodule Astarte.Core.Generators.Interface do
             expiry: expiry,
             allow_unset: allow_unset,
             explicit_timestamp: explicit_timestamp
-          },
+          ],
           mappings <- gen_param(mappings(mappings_args), :mappings, params)
         ) do
       %{

--- a/lib/parameterized_streams.ex
+++ b/lib/parameterized_streams.ex
@@ -1,0 +1,25 @@
+defmodule ParameterizedStreams do
+  @moduledoc """
+  Utilities to allow creating parametric streams by allowing the user to override target values with
+  custom values or generators
+  """
+  import StreamData
+
+  @type stream() :: StreamData.t(term())
+
+  @spec gen_param(stream(), atom(), keyword()) :: stream()
+  def gen_param(default_gen, param_name, params) do
+    case Keyword.fetch(params, param_name) do
+      {:ok, value} ->
+        if generator?(value), do: value, else: constant(value)
+
+      :error ->
+        default_gen
+    end
+  end
+
+  # TODO: handle {stream(), stream()} type generators
+  defp generator?(value) do
+    is_struct(value, StreamData)
+  end
+end

--- a/test/parameterized_streams_test.exs
+++ b/test/parameterized_streams_test.exs
@@ -1,0 +1,128 @@
+defmodule ParameterizedStreamsTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  import ParameterizedStreams
+
+  describe "gen_param/3" do
+    property "returns the default generator when the value is not being overridden" do
+      check all default_generator <- generator(),
+                param_not_in_user_params <- atom(:alphanumeric),
+                user_params <- keyword_of(one_of([generator(), term()])),
+                user_params = Keyword.delete(user_params, param_not_in_user_params) do
+        assert gen_param(default_generator, param_not_in_user_params, user_params) ==
+                 default_generator
+      end
+    end
+
+    property "returns the custom generator when the value is being overridden with a generator" do
+      check all default_generator <- generator(),
+                user_params <- list_of({atom(:alphanumeric), generator()}, min_length: 1) do
+        {param, custom_gen} = List.first(user_params)
+        assert gen_param(default_generator, param, user_params) == custom_gen
+      end
+    end
+
+    property "always returns the custom value when the value is being overridden with a constant" do
+      check all default_generator <- generator(),
+                user_params <- list_of({atom(:alphanumeric), term()}, min_length: 1),
+                {param, custom_value} = List.first(user_params),
+                generated_value <- gen_param(default_generator, param, user_params) do
+        assert generated_value == custom_value
+      end
+    end
+  end
+
+  describe "generators using gen_param/3" do
+    property "generate correctly with default parameters" do
+      check all a <- a() do
+        refute is_nil(a)
+      end
+    end
+
+    property "can have their values overridden with a constant" do
+      check all id <- integer(),
+                b <- list_of(b()),
+                a <- a(id: id, b: b) do
+        assert a.id == id
+        assert a.b == b
+      end
+    end
+
+    property "can have their values overridden with a custom generator" do
+      check all a <- a(b: string(:printable)) do
+        assert is_binary(a.b)
+      end
+    end
+
+    property "can be overridden when used as parameters for other generators" do
+      check all id <- integer(),
+                a <- a(b: fixed_list([b(id: id)])) do
+        assert [b] = a.b
+        assert b.id == id
+      end
+    end
+
+    property "can be overridden when used as parameters for other generators two levels deep" do
+      check all c_id <- integer(),
+                a <- a(b: list_of(b(c: list_of(c(id: constant(c_id)))))) do
+        c = a.b |> Enum.flat_map(& &1.c)
+        assert Enum.all?(c, &(&1.id == c_id))
+      end
+    end
+  end
+
+  defp a(params \\ []) do
+    gen all id <- gen_param(integer(), :id, params),
+            b <- gen_param(list_of(b(), max_length: 3), :b, params) do
+      %{id: id, b: b}
+    end
+  end
+
+  defp b(params \\ []) do
+    gen all id <- gen_param(integer(), :id, params),
+            c <- gen_param(list_of(c(), max_length: 3), :c, params) do
+      %{id: id, c: c}
+    end
+  end
+
+  defp c(params \\ []) do
+    gen all id <- gen_param(integer(), :id, params) do
+      %{id: id}
+    end
+  end
+
+  defp generator do
+    member_of([
+      atom(:alphanumeric),
+      atom(:alias),
+      bitstring(),
+      boolean(),
+      byte(),
+      chardata(),
+      codepoint(),
+      bind(term(), &constant/1),
+      float(),
+      integer(),
+      iodata(),
+      iolist(),
+      keyword_of(term()),
+      list_of(term()),
+      map_of(term(), term()),
+      mapset_of(term()),
+      maybe_improper_list_of(term(), term()),
+      member_of(list_of(term(), min_length: 1) |> Enum.at(0)),
+      non_negative_integer(),
+      positive_integer(),
+      string(:ascii),
+      string(:alphanumeric),
+      string(:printable),
+      string(:utf8),
+      term(),
+      tuple({term(), term()}),
+      tuple({term(), term(), term()}),
+      tuple({term(), term(), term(), term()}),
+      uniq_list_of(term())
+    ])
+  end
+end


### PR DESCRIPTION
generators are now parametric so that each parameter can be overridden.

the logic is being kept as simple as possible intentionally, to validate the approach first.

this comes at the cost of the following downsides:
- not _all_ valid generators are treated as such: tuples of generators are being treated as constants
- a generator is always interpreted as such, and it's not possible to assign a generator as a static parameter
- to override parameters of a parametric generator, such as interface's generator inside device's, the only solution is declaring the custom interface generator and then use it on the device call

these features are all possible to implement later with ad-hoc syntax or checks, without breaking changes and keeping the happy-path simple.

BREAKING CHANGE: group generator now accepts `device_ids` instead of `devices`. like all other generators, it requires the values themselves
BREAKING CHANGE: the mapping generator now accepts a keyword list like all other generators instead of a map