### PR TITLE
fix: ErrorRange generating invalid values

### DIFF
--- a/lib/astarte/core/generators/triggers/policy/error_range.ex
+++ b/lib/astarte/core/generators/triggers/policy/error_range.ex
@@ -38,9 +38,6 @@ defmodule Astarte.Core.Generators.Triggers.Policy.ErrorRange do
   end
 
   defp error_codes do
-    one_of([
-      integer(400..599),
-      list_of(integer(400..599), min_length: 1)
-    ])
+    list_of(integer(400..599), min_length: 1)
   end
 end

--- a/test/astarte/core/generators/triggers/policy/error_keyword_test.exs
+++ b/test/astarte/core/generators/triggers/policy/error_keyword_test.exs
@@ -32,8 +32,10 @@ defmodule Astarte.Core.Generators.Triggers.Policy.ErrorKeywordTest do
   @moduletag :error_keyword
 
   defp validation_helper(error_keyword) do
-    error_keyword
-    |> Changeset.change()
+    changes = Map.from_struct(error_keyword)
+
+    %ErrorKeyword{}
+    |> Changeset.change(changes)
     |> ErrorKeyword.validate()
   end
 

--- a/test/astarte/core/generators/triggers/policy/error_range_test.exs
+++ b/test/astarte/core/generators/triggers/policy/error_range_test.exs
@@ -32,8 +32,10 @@ defmodule Astarte.Core.Generators.Triggers.Policy.ErrorRangeTest do
   @moduletag :error_range
 
   defp validation_helper(error_keyword) do
-    error_keyword
-    |> Changeset.change()
+    changes = Map.from_struct(error_keyword)
+
+    %ErrorRange{}
+    |> Changeset.change(changes)
     |> ErrorRange.validate()
   end
 


### PR DESCRIPTION
ErrorRange's `error_codes` is declared as an `{:array, :integer}`. Reflect this in the generator by disallowing single integers.

Fix validations in tests