### PR TITLE
feat(policy): init

### DIFF
--- a/lib/astarte/core/generators/triggers/policy/policy.ex
+++ b/lib/astarte/core/generators/triggers/policy/policy.ex
@@ -1,0 +1,119 @@
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Core.Generators.Triggers.Policy do
+  @moduledoc """
+  This module provides generators for Astarte Policy structs.
+
+  See https://docs.astarte-platform.org/astarte/latest/040-interface_schema.html#mapping
+  """
+
+  use ExUnitProperties
+
+  alias Astarte.Core.Triggers.Policy
+  alias Astarte.Core.Triggers.Policy.ErrorKeyword
+  alias Astarte.Core.Triggers.Policy.ErrorRange
+  alias Astarte.Core.Triggers.Policy.Handler
+
+  @spec policy :: StreamData.t(Policy.t())
+  def policy do
+    gen all retry_times <- integer(1..100),
+            fields <-
+              optional_map(
+                %{
+                  name: policy_name(),
+                  error_handlers: policy_handlers(),
+                  maximum_capacity: integer(1..1_000_000),
+                  event_ttl: integer(1..86_400),
+                  prefetch_count: integer(1..300)
+                },
+                [:event_ttl, :prefetch_count]
+              ) do
+      retry_times =
+        case Enum.all?(fields.error_handlers, &Handler.discards?/1) do
+          true -> nil
+          false -> retry_times
+        end
+
+      fields = fields |> Map.put(:retry_times, retry_times)
+      struct(Policy, fields)
+    end
+  end
+
+  defp policy_name do
+    string(:utf8, min_length: 1, max_length: 128)
+    |> filter(fn <<first::utf8, _rest::binary>> -> first != ?@ end)
+  end
+
+  defp policy_handlers do
+    gen all keywords <-
+              one_of([
+                constant(["any_error"]),
+                uniq_list_of(member_of(["client_error", "server_error"]), max_length: 2)
+              ]),
+            error_codes <- policy_handler_error_codes_from_used_keywords(keywords) do
+      total_handlers = length(keywords) + length(error_codes)
+      strategies = member_of(["discard", "retry"]) |> Enum.take(total_handlers)
+
+      keywords =
+        keywords
+        |> Enum.map(&%ErrorKeyword{keyword: &1})
+
+      ranges = error_codes |> Enum.map(&%ErrorRange{error_codes: &1})
+
+      Enum.concat(keywords, ranges)
+      |> Enum.shuffle()
+      |> Enum.zip(strategies)
+      |> Enum.map(fn {error_type, strategy} ->
+        %Handler{on: error_type, strategy: strategy}
+      end)
+    end
+  end
+
+  defp policy_handler_error_codes_from_used_keywords(keywords) do
+    all_error_codes = 400..599 |> MapSet.new()
+
+    used_codes =
+      keywords
+      |> Enum.map(&%Handler{on: %ErrorKeyword{keyword: &1}})
+      |> Enum.map(&Handler.error_set/1)
+      |> Enum.concat()
+      |> MapSet.new()
+
+    allowed_codes = MapSet.difference(all_error_codes, used_codes)
+
+    case Enum.empty?(allowed_codes) do
+      true ->
+        constant([])
+
+      false ->
+        gen all codes <- list_of(member_of(allowed_codes), min_length: 1) do
+          # avoid uniq_list_of because of the small sample size
+          codes = Enum.uniq(codes)
+          gen_policy_handler_error_codes(codes)
+        end
+    end
+  end
+
+  defp gen_policy_handler_error_codes([]), do: []
+
+  defp gen_policy_handler_error_codes(l) do
+    chunk_length = :rand.uniform(length(l))
+    {chunk, rest} = l |> Enum.shuffle() |> Enum.split(chunk_length)
+    [chunk | gen_policy_handler_error_codes(rest)]
+  end
+end

--- a/test/astarte/core/generators/triggers/policy/policy_test.exs
+++ b/test/astarte/core/generators/triggers/policy/policy_test.exs
@@ -1,0 +1,89 @@
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Core.Generators.Triggers.PolicyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Astarte.Core.Generators.Triggers.Policy, as: PolicyGenerator
+  alias Astarte.Core.Triggers.Policy
+  alias Astarte.Core.Triggers.Policy.ErrorKeyword
+  alias Astarte.Core.Triggers.Policy.ErrorRange
+  alias Astarte.Core.Triggers.Policy.Handler
+
+  defp error_handler_changes_from_struct(handler) do
+    %Handler{on: on, strategy: strategy} = handler
+
+    random_element = :rand.uniform(2)
+
+    on =
+      case {on, random_element} do
+        {%ErrorKeyword{keyword: keyword}, 1} -> keyword
+        {%ErrorKeyword{keyword: keyword}, 2} -> %{"keyword" => keyword}
+        {%ErrorRange{error_codes: error_codes}, 1} -> error_codes
+        {%ErrorRange{error_codes: error_codes}, 2} -> %{"error_codes" => error_codes}
+      end
+
+    %{on: on, strategy: strategy}
+  end
+
+  defp changes_from_struct(policy) do
+    %Policy{
+      name: name,
+      maximum_capacity: maximum_capacity,
+      retry_times: retry_times,
+      event_ttl: event_ttl,
+      prefetch_count: prefetch_count,
+      error_handlers: error_handlers
+    } = policy
+
+    error_handlers = Enum.map(error_handlers, &error_handler_changes_from_struct/1)
+
+    %{
+      name: name,
+      maximum_capacity: maximum_capacity,
+      retry_times: retry_times,
+      event_ttl: event_ttl,
+      prefetch_count: prefetch_count,
+      error_handlers: error_handlers
+    }
+  end
+
+  defp validation_helper(policy) do
+    changes = changes_from_struct(policy)
+
+    %Policy{}
+    |> Policy.changeset(changes)
+  end
+
+  defp validation_fixture(_context), do: {:ok, validate: &validation_helper/1}
+
+  @doc false
+  describe "triggers policy generator" do
+    @describetag :success
+    @describetag :ut
+
+    setup :validation_fixture
+
+    property "generates valid policies", %{validate: validate} do
+      check all error_range <- PolicyGenerator.policy(),
+                changeset = validate.(error_range) do
+        assert changeset.valid?, "Invalid policy: #{inspect(changeset.errors)}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
this adds a generator for policies.

to allow for an efficient generation of handlers, the previous `ErrorRange` and `ErrorKeyword` generators were not used.

This is because of the requirement that there must be no intersection between the handled range for each handler, and the fact that there is a small range of possible errors