### PR TITLE
fix(interface): mapping value_type

### DIFF
--- a/lib/astarte/core/generators/mapping.ex
+++ b/lib/astarte/core/generators/mapping.ex
@@ -120,7 +120,7 @@ defmodule Astarte.Core.Generators.Mapping do
        }) do
     fixed_map(%{
       endpoint: endpoint(aggregation, prefix),
-      type: type(),
+      value_type: type(),
       retention: constant(retention),
       reliability: constant(reliability),
       explicit_timestamp: constant(explicit_timestamp),

--- a/test/astarte/core/generators/interface_test.exs
+++ b/test/astarte/core/generators/interface_test.exs
@@ -49,14 +49,22 @@ defmodule Astarte.Core.Generators.InterfaceTest do
       explicit_timestamp: explicit_timestamp
     }
 
-    Map.from_struct(mapping)
+    mapping = Map.from_struct(mapping)
+    {value_type, mapping} = Map.pop(mapping, :value_type)
+
+    mapping
+    |> Map.put(:type, value_type)
     |> Map.merge(nilified_params)
   end
 
   defp mapping_changes(:datastream, mapping) do
     allow_unset = if mapping.allow_unset == false, do: nil, else: mapping.allow_unset
 
-    Map.from_struct(mapping)
+    mapping = Map.from_struct(mapping)
+    {value_type, mapping} = Map.pop(mapping, :value_type)
+
+    mapping
+    |> Map.put(:type, value_type)
     |> Map.put(:allow_unset, allow_unset)
   end
 


### PR DESCRIPTION
the type of the mapping is called `type` in the changeset and `value_type` in the struct

use the struct's name as it's what is needed by astarte components
