### PR TITLE
build: update formatter options for params gen all

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -16,15 +16,26 @@
 # limitations under the License.
 #
 
+locals_without_parens = [
+  # stream_data
+  all: :*,
+  check: 1,
+  check: 2,
+  property: 1,
+  property: 2,
+
+  # astarte_generators
+  gen: :*
+]
+
 [
-  import_deps: [
-    :stream_data
-  ],
   inputs: [
     "lib/**/*.{ex,exs}",
     "test/**/*.{ex,exs}",
     "mix.exs",
     "config/**/*.{ex,exs}",
     ".credo.exs"
-  ]
+  ],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]

--- a/lib/astarte/utilities/params_gen.ex
+++ b/lib/astarte/utilities/params_gen.ex
@@ -45,12 +45,10 @@ defmodule Astarte.Generators.Utilities.ParamsGen do
 
     # Override the default integer generator using params gen all
     def parametric_generators(params \\ [a: { 2, 3, 4}])
-    params gen(
-      all a <- integer(),
-          b <- list_of(string(:ascii)),
-          c <- constant({:amicizia, "dottore"}),
-          params: params
-    ) do
+    params gen all a <- integer(),
+                   b <- list_of(string(:ascii)),
+                   c <- constant({:amicizia, "dottore"}),
+                   params: params do
         {a, b, c}
       end
   end

--- a/test/astarte/utilities/params_gen_test.exs
+++ b/test/astarte/utilities/params_gen_test.exs
@@ -25,22 +25,18 @@ defmodule Astarte.Generators.Utilities.ParamsGenTest do
   @moduletag :fans
 
   defp gen_helper do
-    params gen(
-             all a <- integer(0..0),
-                 b <- string(?a..?a, length: 1),
-                 c <- constant("friend")
-           ) do
+    params gen all a <- integer(0..0),
+                   b <- string(?a..?a, length: 1),
+                   c <- constant("friend") do
       {a, b, c}
     end
   end
 
   defp param_gen_helper(params) do
-    params gen(
-             all a <- integer(0..0),
-                 b <- string(?a..?a, length: 1),
-                 c <- constant("friend"),
-                 params: params
-           ) do
+    params gen all a <- integer(0..0),
+                   b <- string(?a..?a, length: 1),
+                   c <- constant("friend"),
+                   params: params do
       {a, b, c}
     end
   end


### PR DESCRIPTION
- add it to locals_without_parens so that it's formatted just like stream_data
- export the previous option
- re-export stream_data's generators, so that this is the only library that needs importing