### PR TITLE
Ensure realm_name generator always produces names with length >= 2

### DIFF
--- a/lib/astarte/core/generators/realm.ex
+++ b/lib/astarte/core/generators/realm.ex
@@ -33,7 +33,7 @@ defmodule Astarte.Core.Generators.Realm do
   def realm_name do
     gen all(
           first <- string([?a..?z], length: 1),
-          rest <- string([?a..?z, ?0..?9], length: 0..47)
+          rest <- string([?a..?z, ?0..?9], length: 1..47)
         ) do
       first <> rest
     end


### PR DESCRIPTION
Modified the `realm_name` generator to guarantee a minimum total length of 2 characters by enforcing a minimum length of 1 for the 'rest' portion. This avoids single-character names and reduces the likelihood of duplicate values during testing or seeding.