### PR TITLE
fix: params gen all manage "=" op

### DIFF
--- a/lib/astarte/utilities/params_gen.ex
+++ b/lib/astarte/utilities/params_gen.ex
@@ -47,7 +47,7 @@ defmodule Astarte.Generators.Utilities.ParamsGen do
     def parametric_generators(params \\ [a: { 2, 3, 4}])
     params gen all a <- integer(),
                    b <- list_of(string(:ascii)),
-                   c <- constant({:amicizia, "dottore"}),
+                   c <- constant({:atom, "string"}),
                    params: params do
         {a, b, c}
       end
@@ -99,9 +99,7 @@ defmodule Astarte.Generators.Utilities.ParamsGen do
   defp stream_data?({%StreamData{}, %StreamData{}} = _term), do: true
   defp stream_data?(_), do: false
 
-  @doc """
-  Function called from the macro, to wrap generators
-  """
+  @doc false
   @type stream() :: StreamData.t(term())
   @spec gen_param(stream(), atom(), keyword()) :: stream()
   def gen_param(default_gen, param_name, params) do
@@ -134,7 +132,9 @@ defmodule Astarte.Generators.Utilities.ParamsGen do
     compile_clauses(tail, params, [clause | acc])
   end
 
-  defp compile_clauses(clauses, params), do: compile_clauses(clauses, params, [])
+  defp compile_clauses([{:=, _, _} = clause | tail], params, acc) do
+    compile_clauses(tail, params, [clause | acc])
+  end
 
   defp split_clauses_and_params(clauses_and_params) do
     case Enum.split_while(clauses_and_params, &(not Keyword.keyword?(&1))) do
@@ -147,7 +147,7 @@ defmodule Astarte.Generators.Utilities.ParamsGen do
     {clauses, params} = split_clauses_and_params(clauses_and_params)
 
     clauses =
-      compile_clauses(clauses, params)
+      compile_clauses(clauses, params, [])
       |> Enum.reverse()
 
     quote do

--- a/test/astarte/utilities/params_gen_test.exs
+++ b/test/astarte/utilities/params_gen_test.exs
@@ -41,6 +41,19 @@ defmodule Astarte.Generators.Utilities.ParamsGenTest do
     end
   end
 
+  defp param_gen_eq_helper(params) do
+    params gen all a <- integer(0..0),
+                   {:ok, 0} = {:ok, a},
+                   a1 = a,
+                   b <- string(?a..?a, length: 1),
+                   b1 = b,
+                   c <- constant("friend"),
+                   c1 = c,
+                   params: params do
+      {a1, b1, c1}
+    end
+  end
+
   defp gen_params do
     gen all a <- integer(), b <- string(:ascii) do
       [a: a, b: b]
@@ -56,6 +69,7 @@ defmodule Astarte.Generators.Utilities.ParamsGenTest do
       :ok,
       gen: &gen_helper/0,
       param_gen: &param_gen_helper/1,
+      param_gen_eq: &param_gen_eq_helper/1,
       gen_params: &gen_params/0,
       function_params: &function_params/1
     }
@@ -75,6 +89,21 @@ defmodule Astarte.Generators.Utilities.ParamsGenTest do
              } do
       check all {a1, b1, c1} <- gen.(),
                 {a2, b2, c2} <- param_gen.([]),
+                max_runs: 1 do
+        assert a1 == a2
+        assert b1 == b2
+        assert c1 == c2
+      end
+    end
+
+    @tag :issue
+    property "param gen all does not crash using = op",
+             %{
+               gen: gen,
+               param_gen_eq: param_gen_eq
+             } do
+      check all {a1, b1, c1} <- gen.(),
+                {a2, b2, c2} <- param_gen_eq.([]),
                 max_runs: 1 do
         assert a1 == a2
         assert b1 == b2


### PR DESCRIPTION
Currently, `params gen all` cannot handle the `=` operator within the `gen all` generation chain.

## Example error
```
== Compilation error in file test/astarte/utilities/params_gen_test.exs ==
** (FunctionClauseError) no function clause matching in Astarte.Generators.Utilities.ParamsGen.compile_clauses/3    
    
    The following arguments were given to Astarte.Generators.Utilities.ParamsGen.compile_clauses/3:
  
[{:=, [line: 46], [{:a1, [line: 46], nil}, {:a, [line: 46], nil}]}, {:<-, [line: 47], [{:b, [line: 47], nil}, {:string, [line: 47], [{:.., [line: 47], ~c"aa"}, [length: 1]]}]}, {:=, [line: 48], [{:b1, [line: 48], nil}, {:b, [line: 48], nil}]}, {:<-, [line: 49], [{:c, [line: 49], nil}, {:constant, [line: 49], ["friend"]}]}, {:=, [line: 50], [{:c1, [line: 50], nil}, {:c, [line: 50], nil}]}]
```

The PR fixes this bug