### PR TITLE
timestamp defaulted to seconds

### DIFF
--- a/lib/astarte/common/generators/datetime.ex
+++ b/lib/astarte/common/generators/datetime.ex
@@ -26,13 +26,15 @@ defmodule Astarte.Common.Generators.DateTime do
 
   alias Astarte.Common.Generators.Timestamp, as: TimestampGenerator
 
+  @ref_unit :microsecond
+
   @doc false
   @spec min_default :: DateTime.t()
-  def min_default, do: TimestampGenerator.min_default() |> DateTime.from_unix!(:microsecond)
+  def min_default, do: TimestampGenerator.min_default() |> DateTime.from_unix!(@ref_unit)
 
   @doc false
   @spec max_default :: DateTime.t()
-  def max_default, do: TimestampGenerator.max_default() |> DateTime.from_unix!(:microsecond)
+  def max_default, do: TimestampGenerator.max_default() |> DateTime.from_unix!(@ref_unit)
 
   @doc """
   Generates a random DateTime from min to max (see Timestamp generator)
@@ -44,13 +46,13 @@ defmodule Astarte.Common.Generators.DateTime do
       params gen all min <- constant(min_default()),
                      max <- constant(max_default()),
                      params: params do
-        {DateTime.to_unix(min, :microsecond), DateTime.to_unix(max, :microsecond)}
+        {DateTime.to_unix(min, @ref_unit), DateTime.to_unix(max, @ref_unit)}
       end
 
     gen all {min, max} <- config,
             date_time <-
-              TimestampGenerator.timestamp(min: min, max: max)
-              |> map(&DateTime.from_unix!(&1, :microsecond)) do
+              TimestampGenerator.timestamp(min: min, max: max, unit: @ref_unit)
+              |> map(&DateTime.from_unix!(&1, @ref_unit)) do
       date_time
     end
   end

--- a/lib/astarte/common/generators/timestamp.ex
+++ b/lib/astarte/common/generators/timestamp.ex
@@ -27,13 +27,20 @@ defmodule Astarte.Common.Generators.Timestamp do
   @min_default 0
   @max_default 2_556_143_999_999_999
 
+  @ref_unit :microsecond
+  @default_unit :second
+
   @doc false
   @spec min_default() :: integer()
-  def min_default, do: @min_default
+  @spec min_default(unit :: atom()) :: integer()
+  def min_default(unit \\ @default_unit),
+    do: @min_default |> System.convert_time_unit(@ref_unit, unit)
 
   @doc false
   @spec max_default() :: integer()
-  def max_default, do: @max_default
+  @spec max_default(unit :: atom()) :: integer()
+  def max_default(unit \\ @default_unit),
+    do: @max_default |> System.convert_time_unit(@ref_unit, unit)
 
   @doc """
   Generates a random timestamp between min and max, defaulting to 0 and 2_556_143_999_999_999 (µs).
@@ -42,8 +49,9 @@ defmodule Astarte.Common.Generators.Timestamp do
   @spec timestamp(params :: keyword()) :: StreamData.t(integer())
   def timestamp(params \\ []) do
     config =
-      params gen all min <- constant(min_default()),
-                     max <- constant(max_default()),
+      params gen all unit <- constant(@default_unit),
+                     min <- constant(min_default(unit)),
+                     max <- constant(max_default(unit)),
                      params: params do
         {min, max}
       end

--- a/test/astarte/common/generators/timestamp_test.exs
+++ b/test/astarte/common/generators/timestamp_test.exs
@@ -32,7 +32,7 @@ defmodule Astarte.Common.Generators.TimestampTest do
   describe "timestamp generator" do
     property "valid generic timestamp" do
       check all timestamp <- TimestampGenerator.timestamp() do
-        assert {:ok, _} = DateTime.from_unix(timestamp, :microsecond)
+        assert {:ok, _} = DateTime.from_unix(timestamp)
       end
     end
 


### PR DESCRIPTION
for backward compatibility with the rest of the `astarte` platform, `Timestamp` generator uses `:second` as its output unit, although internally it works in `:microsecond`