### PR TITLE
refactor!: storage_type generated based on a valid interface

### DIFF
--- a/lib/astarte/core/generators/storage_type.ex
+++ b/lib/astarte/core/generators/storage_type.ex
@@ -20,6 +20,7 @@ defmodule Astarte.Core.Generators.StorageType do
   @moduledoc """
   This module provides generators for StorageType.
   """
+  alias Astarte.Core.Interface
   alias Astarte.Core.StorageType
 
   use ExUnitProperties
@@ -27,15 +28,23 @@ defmodule Astarte.Core.Generators.StorageType do
   @doc """
   Generates a valid Astarte StorageType
   """
-  @spec storage_type() :: StreamData.t(StorageType.t())
-  def storage_type do
-    member_of([
-      :multi_interface_individual_properties_dbtable,
-      :multi_interface_individual_datastream_dbtable,
-      :one_individual_properties_dbtable,
-      :one_individual_datastream_dbtable,
-      :one_object_datastream_dbtable
-    ])
+  @spec storage_type(Interface.t()) :: StreamData.t(StorageType.t())
+  def storage_type(%Interface{} = interface) do
+    interface |> constant() |> storage_type()
+  end
+
+  @spec storage_type(StreamData.t(Interface.t())) :: StreamData.t(StorageType.t())
+  def storage_type(gen) do
+    gen all %Interface{
+              type: type,
+              aggregation: aggregation
+            } <- gen do
+      case {type, aggregation} do
+        {:properties, :individual} -> :multi_interface_individual_properties_dbtable
+        {:datastream, :individual} -> :multi_interface_individual_datastream_dbtable
+        {:datastream, :object} -> :one_object_datastream_dbtable
+      end
+    end
   end
 
   @doc """

--- a/test/astarte/core/generators/storage_type_test.exs
+++ b/test/astarte/core/generators/storage_type_test.exs
@@ -25,6 +25,7 @@ defmodule Astarte.Core.Generators.StorageTypeTest do
 
   alias Astarte.Core.StorageType
 
+  alias Astarte.Core.Generators.Interface, as: InterfaceGenerator
   alias Astarte.Core.Generators.StorageType, as: StorageTypeGenerator
 
   @moduletag :core
@@ -35,15 +36,24 @@ defmodule Astarte.Core.Generators.StorageTypeTest do
     @describetag :success
     @describetag :ut
 
-    property "validate storage_type using atoms" do
-      check all changes <- StorageTypeGenerator.storage_type() do
+    property "validate storage_type using atoms and interface (generator)" do
+      check all changes <- InterfaceGenerator.interface() |> StorageTypeGenerator.storage_type() do
+        assert {:ok, _} = StorageType.cast(changes), "Invalid cast from #{changes}"
+      end
+    end
+
+    property "validate storage_type using atoms and interface (struct)" do
+      check all interface <- InterfaceGenerator.interface(),
+                changes <- StorageTypeGenerator.storage_type(interface) do
         assert {:ok, _} = StorageType.cast(changes), "Invalid cast from #{changes}"
       end
     end
 
     property "validate storage_type using integer" do
       gen_storage_type_changes =
-        StorageTypeGenerator.storage_type() |> StorageTypeGenerator.to_changes()
+        InterfaceGenerator.interface()
+        |> StorageTypeGenerator.storage_type()
+        |> StorageTypeGenerator.to_changes()
 
       check all changes <- gen_storage_type_changes do
         assert {:ok, _} = StorageType.cast(changes), "Invalid cast from #{changes}"


### PR DESCRIPTION
## Breaking changes

`storage_type` only makes sense in the specific context when has a valid `interface` or `InterfaceGenerator`