### PR TITLE
fix: allow result from to_changes to be encoded in json

### DIFF
--- a/lib/astarte/core/generators/interface.ex
+++ b/lib/astarte/core/generators/interface.ex
@@ -80,7 +80,6 @@ defmodule Astarte.Core.Generators.Interface do
   @spec to_changes(StreamData.t(Interface.t())) :: StreamData.t(map())
   def to_changes(gen) do
     gen all %Interface{
-              interface_id: interface_id,
               name: name,
               major_version: major_version,
               minor_version: minor_version,
@@ -108,7 +107,6 @@ defmodule Astarte.Core.Generators.Interface do
         doc: doc,
         # Different input naming
         interface_name: name,
-        interface_id: interface_id,
         version_major: major_version,
         version_minor: minor_version
       })

--- a/lib/astarte/core/generators/mapping.ex
+++ b/lib/astarte/core/generators/mapping.ex
@@ -89,7 +89,10 @@ defmodule Astarte.Core.Generators.Mapping do
   @spec to_changes(StreamData.t(Mapping.t())) :: StreamData.t(map())
   def to_changes(gen) do
     gen all mapping <- gen do
-      mapping |> Map.from_struct() |> MapUtilities.clean()
+      mapping
+      |> Map.from_struct()
+      |> Map.drop([:interface_id, :endpoint_id])
+      |> MapUtilities.clean()
     end
   end
 

--- a/test/astarte/core/generators/interface_test.exs
+++ b/test/astarte/core/generators/interface_test.exs
@@ -67,4 +67,15 @@ defmodule Astarte.Core.Generators.InterfaceTest do
       end
     end
   end
+
+  describe "to_changes/1" do
+    @describetag :success
+    @describetag :ut
+    property "allows the resulting map to be json encoded" do
+      check all interface <- InterfaceGenerator.interface(),
+                changes <- InterfaceGenerator.to_changes(interface) do
+        assert {:ok, _json} = Jason.encode(changes)
+      end
+    end
+  end
 end


### PR DESCRIPTION
remove interface and endpoint ids from interfaces and mapping in order to allow the resulting map to be json encodeable

the result of to_changes should be thought of as the parameter to give the changeset functions in order to create the struct, and no changeset functions accepts the id parameters anyway