### PR TITLE
fix mapping endpoint generation

### DIFF
--- a/lib/astarte/core/generators/interface.ex
+++ b/lib/astarte/core/generators/interface.ex
@@ -192,7 +192,8 @@ defmodule Astarte.Core.Generators.Interface do
             explicit_timestamp <- MappingGenerator.explicit_timestamp(interface_type),
             mappings <-
               MappingGenerator.endpoint_segment()
-              |> uniq_list_of(min_length: 1, max_length: 10)
+              |> list_of(min_length: 1, max_length: 10)
+              |> map(&Enum.uniq_by(&1, fn endpoint -> String.downcase(endpoint) end))
               |> bind(fn list ->
                 list
                 |> Enum.map(fn postfix ->

--- a/lib/astarte/core/generators/mapping.ex
+++ b/lib/astarte/core/generators/mapping.ex
@@ -117,8 +117,8 @@ defmodule Astarte.Core.Generators.Mapping do
   """
   @spec endpoint_segment() :: StreamData.t(StreamData.t(String.t()))
   def endpoint_segment do
-    gen all prefix <- string(@unix_prefix_path_chars, min_length: 1, max_length: 10),
-            rest <- string(@unix_path_chars, min_length: 1, max_length: 10) do
+    gen all prefix <- string(@unix_prefix_path_chars, length: 1),
+            rest <- string(@unix_path_chars, max_length: 19) do
       prefix <> rest
     end
   end


### PR DESCRIPTION
fix mapping `endpoint_segment`
(only the first char must not be a number)

As a result, the `interface generator` was also changed to prevent it from repeating the same `endpoint` multiple times.