### PR TITLE
test: change max_runs

### DIFF
--- a/config/ci.exs
+++ b/config/ci.exs
@@ -18,7 +18,7 @@
 import Config
 
 config :stream_data,
-  max_runs: 1_000
+  max_runs: 100
 
 config :ex_unit,
   timeout: 120_000

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,3 +16,6 @@
 #
 
 import Config
+
+config :stream_data,
+  max_runs: 50

--- a/test/astarte/common/generators/http_test.exs
+++ b/test/astarte/common/generators/http_test.exs
@@ -41,7 +41,7 @@ defmodule Astarte.Common.Generators.HTTPTest do
     @describetag :success
     @describetag :ut
     property "generate valid RFC3986 URI" do
-      check all url <- HTTPGenerator.url(), max_runs: 200 do
+      check all url <- HTTPGenerator.url() do
         assert {:ok, _} = URI.new(url), "URL not valid RFC3986: #{url}"
       end
     end

--- a/test/astarte/common/generators/mqtt_test.exs
+++ b/test/astarte/common/generators/mqtt_test.exs
@@ -39,7 +39,7 @@ defmodule Astarte.Common.Generators.MQTTTest do
     end
 
     property "generate topics cannot be a null string by default" do
-      check all topic <- MQTTGenerator.mqtt_topic(), max_runs: 1_000 do
+      check all topic <- MQTTGenerator.mqtt_topic() do
         refute String.equivalent?(topic, "")
       end
     end

--- a/test/astarte/core/generators/device_test.exs
+++ b/test/astarte/core/generators/device_test.exs
@@ -63,10 +63,7 @@ defmodule Astarte.Core.Generators.DeviceTest do
   describe "device generator struct" do
     @tag :success
     property "success base device creation" do
-      check all(
-              device <- DeviceGenerator.device(),
-              max_runs: 100
-            ) do
+      check all device <- DeviceGenerator.device() do
         refute is_nil(device)
       end
     end
@@ -85,8 +82,7 @@ defmodule Astarte.Core.Generators.DeviceTest do
                     first_registration: nil,
                     aliases: nil,
                     attributes: nil
-                  ),
-                max_runs: 100 do
+                  ) do
         refute is_nil(device)
       end
     end

--- a/test/astarte/core/generators/mqtt_payload_test.exs
+++ b/test/astarte/core/generators/mqtt_payload_test.exs
@@ -72,8 +72,7 @@ defmodule Astarte.Core.Generators.MQTTPayloadTest do
   property "generated payloads honor the mapping type" do
     check all %Mapping{type: type} = mapping <- MappingGenerator.mapping(),
               payload <- MQTTPayloadGenerator.payload(mapping: mapping),
-              %{"v" => value} = Cyanide.decode!(payload),
-              max_runs: 100 do
+              %{"v" => value} = Cyanide.decode!(payload) do
       assert value_matches_mapping?(type, value)
     end
   end


### PR DESCRIPTION
## Test parameter change

The tests became more resource-intensive, and the 1_000 `max_runs` always led to timeouts.

### Environment
- test: 50
- CI: 100

### Tests
Removed the various `max_runs` in the tests == 100