### PR TITLE
value generator uses params gen all

### DIFF
--- a/lib/astarte/core/generators/mapping/value.ex
+++ b/lib/astarte/core/generators/mapping/value.ex
@@ -21,22 +21,27 @@ defmodule Astarte.Core.Generators.Mapping.Value do
   This module provides generators for Interface values.
   """
   use ExUnitProperties
+  use Astarte.Generators.Utilities.ParamsGen
 
   alias Astarte.Core.Interface
   alias Astarte.Core.Mapping
 
+  alias Astarte.Core.Generators.Interface, as: InterfaceGenerator
   alias Astarte.Core.Generators.Mapping.ValueType, as: ValueTypeGenerator
 
   @doc """
-  Generates a valid value based on interface
+  Generates a valid value based on interface passed or auto-created
   """
-  @spec value(Interface.t()) :: StreamData.t(map())
-  def value(%Interface{} = interface) when not is_struct(interface, StreamData) do
-    interface |> constant() |> value()
-  end
+  @spec value() :: StreamData.t(map())
+  @spec value(params :: keyword()) :: StreamData.t(map())
+  def value(params \\ []) do
+    gen_interface_base =
+      params gen all interface <- InterfaceGenerator.interface(), params: params do
+        interface
+      end
 
-  @spec value(StreamData.t(Interface.t())) :: StreamData.t(map())
-  def value(gen), do: gen |> bind(&build_package/1)
+    gen_interface_base |> bind(&build_package/1)
+  end
 
   defp build_package(%Interface{aggregation: :individual} = interface) do
     %Interface{mappings: mappings} = interface

--- a/test/astarte/core/generators/mapping/value_test.exs
+++ b/test/astarte/core/generators/mapping/value_test.exs
@@ -99,17 +99,15 @@ defmodule Astarte.Core.Generators.Mapping.ValueTest do
     @describetag :success
     @describetag :ut
 
-    property "generates value based on interface (gen)" do
-      gen = InterfaceGenerator.interface() |> ValueGenerator.value()
-
-      check all value <- gen do
+    property "generates value" do
+      check all value <- ValueGenerator.value() do
         assert %{path: _path, value: _value} = value
       end
     end
 
-    property "generates value based on interface (struct)" do
+    property "generates value based on interface" do
       check all interface <- InterfaceGenerator.interface(),
-                value <- ValueGenerator.value(interface) do
+                value <- ValueGenerator.value(interface: interface) do
         assert %{path: _path, value: _value} = value
       end
     end
@@ -117,7 +115,7 @@ defmodule Astarte.Core.Generators.Mapping.ValueTest do
     property "generates value must have mapping path matches endpoint" do
       check all %Interface{mappings: mappings, aggregation: aggregation} = interface <-
                   InterfaceGenerator.interface(),
-                %{path: path, value: _value} <- ValueGenerator.value(interface) do
+                %{path: path, value: _value} <- ValueGenerator.value(interface: interface) do
         assert Enum.any?(mappings, fn %Mapping{endpoint: endpoint} ->
                  ValueGenerator.path_matches_endpoint?(aggregation, endpoint, path)
                end)
@@ -127,7 +125,7 @@ defmodule Astarte.Core.Generators.Mapping.ValueTest do
     property "generates value must be valid type" do
       check all %Interface{mappings: mappings, aggregation: aggregation} = interface <-
                   InterfaceGenerator.interface(),
-                %{path: path, value: value} <- ValueGenerator.value(interface) do
+                %{path: path, value: value} <- ValueGenerator.value(interface: interface) do
         value = value_to_check(aggregation, value)
 
         %Mapping{value_type: value_type} =


### PR DESCRIPTION
For consistency with the rest of the project, a generator can always be used without mandatory references. `params gen all` is used to link it to something created previously.

The fix corrects this setting.