### PR TITLE
Improve consistency of 'database_retention_policy' and 'database_retention_ttl' values in interface aggregate mappings

### DIFF
--- a/lib/astarte/core/generators/interface.ex
+++ b/lib/astarte/core/generators/interface.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2025 SECO Mind Srl
+# Copyright 2025 - 2026 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -207,13 +207,19 @@ defmodule Astarte.Core.Generators.Interface do
               reliability <- MappingGenerator.reliability(interface_type),
               expiry <- MappingGenerator.expiry(interface_type),
               allow_unset <- MappingGenerator.allow_unset(interface_type),
-              explicit_timestamp <- MappingGenerator.explicit_timestamp(interface_type) do
+              explicit_timestamp <- MappingGenerator.explicit_timestamp(interface_type),
+              db_retention_policy <-
+                MappingGenerator.database_retention_policy(interface_type),
+              db_retention_ttl <-
+                MappingGenerator.database_retention_ttl(interface_type, db_retention_policy) do
         [
           retention: retention,
           reliability: reliability,
           expiry: expiry,
           allow_unset: allow_unset,
-          explicit_timestamp: explicit_timestamp
+          explicit_timestamp: explicit_timestamp,
+          database_retention_policy: db_retention_policy,
+          database_retention_ttl: db_retention_ttl
         ]
       end
 

--- a/test/astarte/core/generators/interface_test.exs
+++ b/test/astarte/core/generators/interface_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2025 SECO Mind Srl
+# Copyright 2025 - 2026 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -169,6 +169,25 @@ defmodule Astarte.Core.Generators.InterfaceTest do
       check all changes <- gen_interface_changes,
                 changeset = Interface.changeset(%Interface{}, changes) do
         assert changeset.valid?, "Invalid interface: #{inspect(changeset.errors)}"
+      end
+    end
+
+    @tag issue: 1072
+    property "validate database retention opts in interface aggregate mappings are consistent" do
+      check all interface <- InterfaceGenerator.interface(), max_runs: 100 do
+        %Mapping{
+          database_retention_policy: reference_database_retention_policy,
+          database_retention_ttl: reference_database_retention_ttl
+        } = Enum.at(interface.mappings, 0)
+
+        assert Enum.all?(interface.mappings, fn
+                 %Mapping{
+                   database_retention_policy: mapping_database_retention_policy,
+                   database_retention_ttl: mapping_database_retention_ttl
+                 } ->
+                   mapping_database_retention_policy == reference_database_retention_policy and
+                     mapping_database_retention_ttl == reference_database_retention_ttl
+               end)
       end
     end
   end


### PR DESCRIPTION
Align with the astarte_core improved validation of 'database_retention_policy' and 'database_retention_ttl' values to fix https://github.com/astarte-platform/astarte/issues/1072